### PR TITLE
Stencil missing attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## 1.0.5
+## 1.0.7
+
+- Patched attribute mapping for Stencil
+
+## 1.0.6
 
 - Fix duplicate attributes in `argTypes`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-storybook-helpers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-storybook-helpers",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@open-wc/lit-helpers": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-storybook-helpers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Helpers designed to make integrating Web Components with Storybook easier.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/cem-utilities.ts
+++ b/src/cem-utilities.ts
@@ -26,6 +26,7 @@ export function getAttributesAndProperties(component?: Declaration): ArgTypes {
       return;
     }
 
+    const attribute = component.attributes.find(x => member.name === x.fieldName);
     const propName = member.name;
 
     properties[propName] = {
@@ -43,14 +44,15 @@ export function getAttributesAndProperties(component?: Declaration): ArgTypes {
       return;
     }
 
+    const name = attribute?.name || member.name;
     const type = options.typeRef
       ? (member as any)[`${options.typeRef}`]?.text || member?.type?.text
       : member?.type?.text;
     const propType = cleanUpType(type);
     const defaultValue = removeQuoteWrappers(member.default);
 
-    properties[member.attribute || member.name] = {
-      name: member.attribute || member.name,
+    properties[name] = {
+      name: name,
       description: getDescription(
         member.description,
         propName,
@@ -61,7 +63,7 @@ export function getAttributesAndProperties(component?: Declaration): ArgTypes {
         type: getControl(propType),
       },
       table: {
-        category: member.attribute ? "attributes" : "properties",
+        category: attribute ? "attributes" : "properties",
         defaultValue: {
           summary: defaultValue,
         },
@@ -73,7 +75,7 @@ export function getAttributesAndProperties(component?: Declaration): ArgTypes {
 
     const values = propType?.split("|");
     if (values && values?.length > 1) {
-      properties[propName].options = values.map((x) => removeQuoteWrappers(x)!);
+      properties[name].options = values.map((x) => removeQuoteWrappers(x)!);
     }
   });
 


### PR DESCRIPTION
- add attribute name if missing from `member` object