### PR TITLE
added color control for CSS variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.2.0
+
+- Set control "color" for CSS variables that include the word "color"
+- Removed `ref` control if it is included in the list of React properties.
+
 ## 1.1.1
 
 - Added stricter type checks for determining controls 

--- a/demo/lit-app-v7/custom-elements.json
+++ b/demo/lit-app-v7/custom-elements.json
@@ -10,6 +10,13 @@
           "kind": "class",
           "description": "An example element.",
           "name": "MyElement",
+          "cssProperties": [
+            {
+              "description": "The background color",
+              "name": "--my-element-background-color",
+              "default": "#ccc"
+            }
+          ],
           "cssParts": [
             {
               "description": "The button",

--- a/demo/lit-app-v7/src/my-element.ts
+++ b/demo/lit-app-v7/src/my-element.ts
@@ -24,6 +24,8 @@ type DataObject = {
  * @slot button - This element has a slot
  * @csspart button - The button
  * @csspart label - Adds custom styles to label
+ * 
+ * @cssprop [--my-element-background-color=#ccc] - The background color
  */
 @customElement("my-element")
 export class MyElement extends LitElement {

--- a/demo/lit-app-v7/types/my-element.d.ts
+++ b/demo/lit-app-v7/types/my-element.d.ts
@@ -11,6 +11,8 @@ type DataObject = {
  * @slot button - This element has a slot
  * @csspart button - The button
  * @csspart label - Adds custom styles to label
+ *
+ * @cssprop [--my-element-background-color=#ccc] - The background color
  */
 export declare class MyElement extends LitElement {
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-storybook-helpers",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Helpers designed to make integrating Web Components with Storybook easier.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/cem-utilities.ts
+++ b/src/cem-utilities.ts
@@ -138,6 +138,9 @@ export function getReactProperties(component?: Declaration): ArgTypes {
     }
   });
 
+  // remove ref property if it exists
+  delete properties["ref"];
+
   return properties;
 }
 
@@ -167,7 +170,7 @@ export function getCssProperties(component?: Declaration): ArgTypes {
       description: property.description,
       defaultValue: property.default,
       control: {
-        type: "text",
+        type: (property.name.toLowerCase()).includes('color') ? "color" : "text",
       },
     };
   });
@@ -259,6 +262,7 @@ function getControl(type: string, isAttribute = false): ControlOptions {
   if (hasType(options, "date")) {
     return "date";
   }
+
 
   // if types is a list of string options
   return options.length > 1 ? "select" : "text";


### PR DESCRIPTION
- Added color picker control for CSS variables with the word "color" in them (#25)
- Removed `ref` property from controls if they are included in react props