### PR TITLE
Resolves "Cannot read properties of undefined (reading 'find')" error caused by undef attributes array

### DIFF
--- a/src/cem-utilities.ts
+++ b/src/cem-utilities.ts
@@ -26,7 +26,7 @@ export function getAttributesAndProperties(component?: Declaration): ArgTypes {
       return;
     }
 
-    const attribute = component.attributes.find(
+    const attribute = component.attributes?.find(
       (x) => member.name === x.fieldName
     );
     const propName = member.name;


### PR DESCRIPTION
We found an issue where if members are defined, but attributes are not, it winds up throwing the following error in the Storybook preview:

```
Cannot read properties of undefined (reading 'find')
```

This occurred in a component that has no properties or attribute, that extends from a component with no properties or attributes analyzed with `@open-wc/analyzer`.

We validated the change locally and everything seems to work as intended after the fact.  Credit goes to  @tonjohn, I just made the change. 

Thanks again for all your hard work on this library! 