### PR TITLE
Check for truthiness vs null before spreading attributes

### DIFF
--- a/src/spread.ts
+++ b/src/spread.ts
@@ -216,7 +216,7 @@ export class SpreadDirective extends SpreadEventsDirective {
           break;
         default:
           // standard attribute
-          if (value != null) {
+          if (value) {
             element.setAttribute(key, String(value));
           } else {
             element.removeAttribute(key);


### PR DESCRIPTION
When you pass in `args` into the default export of a story any attribute that does not have a defined default value ends up getting treated as an empty string (`""`), which in turn ends up getting spread onto the component. As a result every possible string attribute that _can_ exist ends up showing up in the docs view. As a consumer I would expect only those that have a defined default value that is setup in the controls tab would show up here as opposed to empty strings for everything, as it keeps the documentation more clear. 

For example, here's a property that was problematic which doesn't have a default value. Because we're using the `ifDefined` directive on a video element in the render method, passing in an empty string ends up breaking this in the docs preview as it's no longer of `undefined|null` type.

```js
@property({type: String})
src;

@property({type: String})
crossorigin;

@property({type: String})
title = 'player'
```

On my component it was rendering like so:

```html
<!-- Unexpected -->
<my-component src="" crossorigin="" title="player"></my-component>

<!-- Expected -->
<my-component title="player"></my-component>
```

Which based on the following results in:

```htm
<!-- Lit -->
<video crossorigin="${ifDefined(this.crossorigin)}" src="${ifDefined(src)}" title="player"></video>

<!-- Rendered -->
<video crossorigin="" src="" title="player"></video>
````

To solve this I've adjusted the spread function to check for truthiness as opposed to a null type check which seems to do the trick, for my use case at least. With this change only defined things in the controls get applied to the component. The alternative would be to update every instance of `ifDefined` to fallback to a `undefined|null` value, ie `ifDefined(this.src || undefined)`, but I personally find it odd that everything shows up as empty strings in the code previews. 

Let me know if this fix makes sense to you, or if there's anything else you think would need changing, there may be some unintended side effects I haven't thought through with this. I wanted to add unit tests but there wasn't a preexisting fixture setup to validate the directives.