### PR TITLE
Fix empty css parts and style tag

### DIFF
--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -66,7 +66,7 @@ export function getTemplate(
  * @returns styles in a tagged template literal
  */
 export function getStyleTemplate(component?: Declaration, args?: any) {
-  const cssPartsTemplate = getCssPartsTemplate(component!, args) || '';
+  const cssPartsTemplate = getCssPartsTemplate(component!, args) || "";
 
   return `${cssPartsTemplate}`.replaceAll(/\s+/g, "") != ""
     ? html`<style>
@@ -155,7 +155,7 @@ function getCssPartsTemplate(component: Declaration, args: any) {
     .filter((key) => key.endsWith("-part"))
     .map((key) => {
       const cssPartName = cssParts[key].name;
-      const cssPartValue = args![key] || '';
+      const cssPartValue = args![key] || "";
       return cssPartValue.replaceAll(/\s+/g, "") !== ""
         ? `${component?.tagName}::part(${cssPartName}) {
               ${cssPartValue || ""}

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -156,7 +156,7 @@ function getCssPartsTemplate(component: Declaration, args: any) {
       .filter((key) => key.endsWith("-part"))
       .map((key) => {
         const cssPartName = cssParts[key].name;
-        const cssPartValue = args![key];
+        const cssPartValue = args![key] || '';
         return cssPartValue?.replaceAll(/\s+/g, "") !== ""
           ? `${component?.tagName}::part(${cssPartName}) {
               ${cssPartValue || ""}

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -66,11 +66,11 @@ export function getTemplate(
  * @returns styles in a tagged template literal
  */
 export function getStyleTemplate(component?: Declaration, args?: any) {
-  const cssPartsTemplate = getCssPartsTemplate(component!, args);
+  const cssPartsTemplate = getCssPartsTemplate(component!, args) || '';
 
-  return `${cssPartsTemplate}`?.replaceAll(/\s+/g, "") != ""
+  return `${cssPartsTemplate}`.replaceAll(/\s+/g, "") != ""
     ? html`<style>
-        ${cssPartsTemplate}
+        ${unsafeStatic(cssPartsTemplate)}
       </style> `
     : "";
 }
@@ -151,21 +151,19 @@ function getCssPartsTemplate(component: Declaration, args: any) {
 
   const cssParts = getCssParts(component);
 
-  return unsafeStatic(
-    `${Object.keys(cssParts)
-      .filter((key) => key.endsWith("-part"))
-      .map((key) => {
-        const cssPartName = cssParts[key].name;
-        const cssPartValue = args![key] || '';
-        return cssPartValue?.replaceAll(/\s+/g, "") !== ""
-          ? `${component?.tagName}::part(${cssPartName}) {
+  return `${Object.keys(cssParts)
+    .filter((key) => key.endsWith("-part"))
+    .map((key) => {
+      const cssPartName = cssParts[key].name;
+      const cssPartValue = args![key] || '';
+      return cssPartValue.replaceAll(/\s+/g, "") !== ""
+        ? `${component?.tagName}::part(${cssPartName}) {
               ${cssPartValue || ""}
             }`
-          : null;
-      })
-      .filter((value) => value !== null)
-      .join("\n")}`
-  );
+        : null;
+    })
+    .filter((value) => value !== null)
+    .join("\n")}`;
 }
 
 /**


### PR DESCRIPTION
- When no CSS Parts value is defined, they don't show up in the story/component source code
- When no styling is defined, the style tag doesn't get rendered in the story/component source code

Tested with Storybook 7

Closes [#35](https://github.com/break-stuff/wc-storybook-helpers/issues/35)