### PR TITLE
Add hideScriptTag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,3 +363,12 @@ It is common for teams to parse or create custom types and add them to the Custo
 ```ts
 setWcStorybookHelpersConfig({ typeRef: "expandedType" });
 ```
+
+### Hide script tag
+
+Every component by default includes a script tag to interact with the component
+over Javascript. The `hideScriptTag` option removes this script tag.
+
+```ts
+setWcStorybookHelpersConfig({ hideScriptTag: true });
+```

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -9,9 +9,16 @@ import {
   getCssProperties,
   getSlots,
 } from "./cem-utilities.js";
+import { Options } from "./storybook";
 
 let argObserver: MutationObserver | undefined;
 let lastTagName: string | undefined;
+
+let options: Options = {};
+
+setTimeout(() => {
+  options = (globalThis as any)?.__WC_STORYBOOK_HELPERS_CONFIG__ || {};
+});
 
 /**
  * Gets the template used to render the component in Storybook
@@ -53,9 +60,13 @@ export function getTemplate(
   >
     ${slotsTemplate}${slot || ""}
 </${unsafeStatic(component!.tagName!)}>
-<script>
-  component = document.querySelector('${component!.tagName!}');
-</script>
+${
+  options.hideScriptTag
+    ? ""
+    : html`<script>
+        component = document.querySelector("${component!.tagName!}");
+      </script>`
+}
 `;
 }
 

--- a/src/storybook.d.ts
+++ b/src/storybook.d.ts
@@ -3,6 +3,8 @@ export interface Options {
   hideArgRef?: boolean;
   /** sets the custom type reference in the Custom Elements Manifest */
   typeRef?: string;
+  /** hides the <script> tag, doens't render it in the story/component source code */
+  hideScriptTag?: boolean;
 }
 
 export interface ArgTypes {


### PR DESCRIPTION
- Add `hideScriptTag` option which, when enabled, doesn't render the script tag in the component source code
- Expands README to describe this new option

Tested in Storybook 7