### PR TITLE
Add hideDefaultAttributeValues option

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,3 +363,12 @@ It is common for teams to parse or create custom types and add them to the Custo
 ```ts
 setWcStorybookHelpersConfig({ typeRef: "expandedType" });
 ```
+
+### Render default attribute values
+
+Default attribute values are omitted from the component source code. To always
+show all default values enable the `renderDefaultAttributeValues` setting:
+
+```ts
+setWcStorybookHelpersConfig({ renderDefaultAttributeValues: true });
+```

--- a/demo/lit-app-v7/.storybook/preview.ts
+++ b/demo/lit-app-v7/.storybook/preview.ts
@@ -3,7 +3,11 @@ import { setCustomElementsManifest } from "@storybook/web-components";
 import customElements from "../custom-elements.json";
 import { setWcStorybookHelpersConfig } from "../../..";
 
-setWcStorybookHelpersConfig({ hideArgRef: false, typeRef: "expandedType" });
+setWcStorybookHelpersConfig({
+  hideArgRef: false,
+  typeRef: "expandedType",
+  // renderDefaultAttributeValues: true,
+});
 setCustomElementsManifest(customElements);
 
 const preview: Preview = {

--- a/demo/lit-app-v7/src/my-element.mdx
+++ b/demo/lit-app-v7/src/my-element.mdx
@@ -1,0 +1,6 @@
+import { Meta, Story, Canvas, Controls } from '@storybook/blocks';
+import * as MyElementStories from './my-element.stories';
+
+# My Element
+
+<Canvas of={MyElementStories.Default} sourceState="shown" />

--- a/demo/lit-app-v7/src/my-element.mdx
+++ b/demo/lit-app-v7/src/my-element.mdx
@@ -4,3 +4,5 @@ import * as MyElementStories from './my-element.stories';
 # My Element
 
 <Canvas of={MyElementStories.Default} sourceState="shown" />
+
+<Controls of={MyElementStories.Default} /> 

--- a/demo/lit-app-v7/src/my-element.stories.ts
+++ b/demo/lit-app-v7/src/my-element.stories.ts
@@ -8,7 +8,7 @@ const { args, events, argTypes, template } =
 
 console.log(args);
 const meta = {
-  title: "Components/My Element",
+  title: "My Element",
   component: "my-element",
   args,
   argTypes,

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -103,7 +103,7 @@ function getTemplateOperators(component: Declaration, args: any) {
     const attrValue = args![key] as unknown;
     const prop: string =
       (attr.control as any).type === "boolean" ? `?${attrName}` : attrName;
-    if (!options.hideDefaultAttributeValues || attrValue !== attributes[key].defaultValue) {
+    if (attrValue !== attributes[key].defaultValue || options.renderDefaultAttributeValues) {
       attrOperators[prop] = attrValue === "false" ? false : attrValue;
     }
   });

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -9,9 +9,16 @@ import {
   getCssProperties,
   getSlots,
 } from "./cem-utilities.js";
+import { Options } from "./storybook";
 
 let argObserver: MutationObserver | undefined;
 let lastTagName: string | undefined;
+
+let options: Options = {};
+
+setTimeout(() => {
+  options = (globalThis as any)?.__WC_STORYBOOK_HELPERS_CONFIG__ || {};
+});
 
 /**
  * Gets the template used to render the component in Storybook
@@ -96,7 +103,9 @@ function getTemplateOperators(component: Declaration, args: any) {
     const attrValue = args![key] as unknown;
     const prop: string =
       (attr.control as any).type === "boolean" ? `?${attrName}` : attrName;
-    attrOperators[prop] = attrValue === "false" ? false : attrValue;
+    if (!options.hideDefaultAttributeValues || attrValue !== attributes[key].defaultValue) {
+      attrOperators[prop] = attrValue === "false" ? false : attrValue;
+    }
   });
 
   Object.keys(args)

--- a/src/storybook.d.ts
+++ b/src/storybook.d.ts
@@ -7,7 +7,7 @@ export interface Options {
    * doesn't render attributes when their value is equal to the default value
    * of that attribute
    */
-  hideDefaultAttributeValues?: boolean;
+  renderDefaultAttributeValues?: boolean;
 }
 
 export interface ArgTypes {

--- a/src/storybook.d.ts
+++ b/src/storybook.d.ts
@@ -3,6 +3,11 @@ export interface Options {
   hideArgRef?: boolean;
   /** sets the custom type reference in the Custom Elements Manifest */
   typeRef?: string;
+  /**
+   * doesn't render attributes when their value is equal to the default value
+   * of that attribute
+   */
+  hideDefaultAttributeValues?: boolean;
 }
 
 export interface ArgTypes {


### PR DESCRIPTION
- Don't render default attribute values
- Add option `renderDefaultAttributeValues` option which, when enabled, does render attributes which have their default value
- Updates v7 demo to include a docs site with a component source code to more easily test source code generation
- Expands README with a description of the `renderDefaultAttributeValues` option

Tested in Storybook 7

Closes [#41](https://github.com/break-stuff/wc-storybook-helpers/issues/41)