### PR TITLE
the real 1.3.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.3.0
+
+- Fixed timing issue with `component` variable in `template()` helper
+- Remove attributes when they match the default value. They can be added back in using the `renderDefaultAttributeValues` setting
+- Add `hideScriptTag` option to hide the script tag section of the template
+- Fix logic to hide styles tag when no CSS parts have been added
+
 ## 1.2.2
 
 - Remove unset attributes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-storybook-helpers",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-storybook-helpers",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@open-wc/lit-helpers": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-storybook-helpers",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Helpers designed to make integrating Web Components with Storybook easier.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/html-templates.ts
+++ b/src/html-templates.ts
@@ -63,7 +63,7 @@ export function getTemplate(
 ${
   options.hideScriptTag
     ? ""
-    : html`<script>
+    : html`<script type="module">
         component = document.querySelector("${component!.tagName!}");
       </script>`
 }


### PR DESCRIPTION
This release includes:

- Fixed timing issue with `component` variable in `template()` helper
- Remove attributes when they match the default value. They can be added back in using the `renderDefaultAttributeValues` setting
- Add `hideScriptTag` option to hide the script tag section of the template
- Fix logic to hide styles tag when no CSS parts have been added