### PR TITLE
React args

### DIFF
--- a/src/cem-utilities.ts
+++ b/src/cem-utilities.ts
@@ -173,6 +173,9 @@ export function getCssProperties(component?: Declaration, enabled = true): ArgTy
       control: enabled ? {
         type: (property.name.toLowerCase()).includes('color') ? "color" : "text",
       } : false,
+      table: {
+        category: "css properties",
+      },
     };
   });
 


### PR DESCRIPTION
- create `reactArgs` result in `getWcStorybookHelpers` for storybook `args` formatted for React
- Fix storybook error that there is an invalid string when default value of a CSS property is just a number