### PR TITLE
remove extra `span` wrapper from slots

### DIFF
--- a/demo/lit-app-v8/src/my-element.stories.ts
+++ b/demo/lit-app-v8/src/my-element.stories.ts
@@ -7,8 +7,6 @@ import { html } from "lit";
 const { args, events, argTypes, template } =
   getWcStorybookHelpers("my-element");
 
-console.log(events);
-
 const meta = {
   title: "My Element",
   component: "my-element",


### PR DESCRIPTION
- remove default `span` wrapper from slots. If the content is being slotted into a named slot, test will be wrapped in a `span` element with the appropriate slot name. Otherwise, a `slot` attribute will be assigned to all immediate child elements with the corresponding slot name.
- fix formatting for CSS parts and slotted content 

closes #60 and #61